### PR TITLE
Fix: broken link

### DIFF
--- a/src/pages/getting-started.mdx
+++ b/src/pages/getting-started.mdx
@@ -49,4 +49,4 @@ WebLN.requestProvider(/* ... */);
 
 ## You're All Set
 
-From here, check out how to use [`requestProvider`](/api/request-provider) and the provider API methods. Make sure you take a look at the source code for each method's demo to fully understand it.
+From here, check out how to use [`requestProvider`](/client/request-provider) and the provider API methods. Make sure you take a look at the source code for each method's demo to fully understand it.


### PR DESCRIPTION
link to requestProvider api reference changed to /client/request-provider